### PR TITLE
Include vanity address generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Features not supported:
 Constructors:
 
 * `generate([icap])` - create an instance based on a new random key (setting `icap` to true will generate an address suitable for the `ICAP Direct mode`)
+* `generateVanityAddress(pattern)` - create an instance where the address is valid against the supplied pattern (**this will be very slow**)
 * `fromPrivateKey(input)` - create an instance based on a raw private key
 * `fromExtendedPrivateKey(input)` - create an instance based on a BIP32 extended private key (xprv)
 * `fromPublicKey(input, [nonStrict])` - create an instance based on a public key (certain methods will not be available)

--- a/index.js
+++ b/index.js
@@ -61,6 +61,21 @@ Wallet.generate = function (icapDirect) {
   }
 }
 
+Wallet.generateVanityAddress = function (pattern) {
+  if (typeof pattern !== 'object') {
+    pattern = new RegExp(pattern)
+  }
+
+  while (true) {
+    var privKey = crypto.randomBytes(32)
+    var address = ethUtil.privateToAddress(privKey)
+
+    if (pattern.test(address.toString('hex'))) {
+      return new Wallet(privKey)
+    }
+  }
+}
+
 Wallet.prototype.getPrivateKey = function () {
   return this.privKey
 }

--- a/test/index.js
+++ b/test/index.js
@@ -108,6 +108,15 @@ describe('.generate()', function () {
   })
 })
 
+describe('.generateVanityAddress()', function () {
+  it('should generate an account with 000 prefix', function () {
+    var wallet = Wallet.generateVanityAddress(/^000/)
+    assert.equal(wallet.getPrivateKey().length, 32)
+    assert.equal(wallet.getAddress()[0], 0)
+    assert.equal(wallet.getAddress()[1] >>> 4, 0)
+  })
+})
+
 describe('.getV3Filename()', function () {
   it('should work', function () {
     assert.equal(fixturewallet.getV3Filename(1457917509265), 'UTC--2016-03-14T01-05-09.265Z--b14ab53e38da1c172f877dbc6d65e4a1b0474c3c')


### PR DESCRIPTION
Not fully sure it is very useful.  It took 800 minutes to find a match for `/^[0123456789]+$/`, which is not a very useful address given it cannot be checksummed using EIP issue 55.