### PR TITLE
Accept the true range of addresses for ICAP direct

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,10 @@ Object.defineProperty(Wallet.prototype, 'pubKey', {
 
 Wallet.generate = function (icapDirect) {
   if (icapDirect) {
+    var max = new ethUtil.BN('088f924eeceeda7fe92e1f5b0fffffffffffffff', 16)
     while (true) {
       var privKey = crypto.randomBytes(32)
-      if (ethUtil.privateToAddress(privKey)[0] === 0) {
+      if (new ethUtil.BN(ethUtil.privateToAddress(privKey)).lte(max)) {
         return new Wallet(privKey)
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 var assert = require('assert')
 var Wallet = require('../')
 var Thirdparty = require('../thirdparty.js')
+var ethUtil = require('ethereumjs-util')
 
 var fixturekey = new Buffer('efca4cdd31923b50f4214af5d2ae10e7ac45a5019e9431cc195482d707485378', 'hex')
 var fixturewallet = Wallet.fromPrivateKey(fixturekey)
@@ -102,9 +103,10 @@ describe('.generate()', function () {
     assert.equal(Wallet.generate().getPrivateKey().length, 32)
   })
   it('should generate an account compatible with ICAP Direct', function () {
+    var max = new ethUtil.BN('088f924eeceeda7fe92e1f5b0fffffffffffffff', 16)
     var wallet = Wallet.generate(true)
     assert.equal(wallet.getPrivateKey().length, 32)
-    assert.equal(wallet.getAddress()[0], 0)
+    assert.equal(new ethUtil.BN(wallet.getAddress()).lte(max), true)
   })
 })
 


### PR DESCRIPTION
The [ICAP](https://github.com/ethereum/wiki/wiki/ICAP:-Inter-exchange-Client-Address-Protocol) document describes direct addresses as <155 bits.

I think the largest 30 character ICAP is the following: `XE43ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ` This decodes to `0x088f924eeceeda7fe92e1f5b0fffffffffffffff` which is 156 bits.

This PR takes anything `<= 0x088f924eeceeda7fe92e1f5b0fffffffffffffff` as valid for ICAP Direct.

The _spec_ also says that "generally these addresses begin with a zero byte" - would some implementations take that as "must begin with zero byte"? If yes, the above code will not generate valid addresses.
