### PR TITLE
Update dependencies

### DIFF
--- a/hdkey.js
+++ b/hdkey.js
@@ -22,9 +22,8 @@ EthereumHDKey.fromExtendedKey = function (base58key) {
 }
 
 EthereumHDKey.prototype.privateExtendedKey = function () {
-  // FIXME: change this according to the outcome of https://github.com/cryptocoinjs/hdkey/issues/7
-  if (!this._hdkey._privateKey) {
-    throw new Error('Private key is not available')
+  if (!this._hdkey.privateExtendedKey) {
+    throw new Error('This is a public key only wallet')
   }
   return this._hdkey.privateExtendedKey
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var Buffer = require('safe-buffer').Buffer
 var ethUtil = require('ethereumjs-util')
 var crypto = require('crypto')
 var scryptsy = require('scrypt.js')
-var uuid = require('uuid')
+var uuidv4 = require('uuid/v4')
 var bs58check = require('bs58check')
 
 function assert (val, msg) {
@@ -145,7 +145,7 @@ Wallet.prototype.toV3 = function (password, opts) {
 
   return {
     version: 3,
-    id: uuid.v4({ random: opts.uuid || crypto.randomBytes(16) }),
+    id: uuidv4({ random: opts.uuid || crypto.randomBytes(16) }),
     address: this.getAddress().toString('hex'),
     crypto: {
       ciphertext: ciphertext.toString('hex'),

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "safe-buffer": "^5.1.1",
     "scrypt.js": "^0.2.0",
     "utf8": "^3.0.0",
-    "uuid": "^2.0.1"
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "coveralls": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/ethereumjs/ethereumjs-wallet",
   "dependencies": {
-    "aes-js": "^0.2.3",
+    "aes-js": "^3.1.0",
     "bs58check": "^2.1.1",
     "ethereumjs-util": "^5.1.4",
     "hdkey": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -27,18 +27,18 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-wallet",
   "dependencies": {
     "aes-js": "^0.2.3",
-    "bs58check": "^1.0.8",
+    "bs58check": "^2.1.1",
     "ethereumjs-util": "^4.4.0",
     "hdkey": "^0.7.0",
     "safe-buffer": "^5.1.1",
     "scrypt.js": "^0.2.0",
-    "utf8": "^2.1.1",
+    "utf8": "^3.0.0",
     "uuid": "^2.0.1"
   },
   "devDependencies": {
-    "coveralls": "^2.11.4",
-    "istanbul": "^0.4.1",
-    "mocha": "^2.3.4",
+    "coveralls": "^3.0.0",
+    "istanbul": "^0.4.5",
+    "mocha": "^5.0.0",
     "standard": "^10.0.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "aes-js": "^3.1.0",
     "bs58check": "^2.1.1",
     "ethereumjs-util": "^5.1.4",
-    "hdkey": "^0.7.0",
+    "hdkey": "^0.8.0",
     "safe-buffer": "^5.1.1",
     "scrypt.js": "^0.2.0",
     "utf8": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "aes-js": "^0.2.3",
     "bs58check": "^2.1.1",
-    "ethereumjs-util": "^4.4.0",
+    "ethereumjs-util": "^5.1.4",
     "hdkey": "^0.7.0",
     "safe-buffer": "^5.1.1",
     "scrypt.js": "^0.2.0",

--- a/test/hdkey.js
+++ b/test/hdkey.js
@@ -32,7 +32,7 @@ describe('.fromExtendedKey()', function () {
     assert.equal(hdnode.publicExtendedKey(), 'xpub661MyMwAqRbcGout4B6s29b6gGQsowyoiF6UgXBEr7eFCWYfXuZDvRxP9zEh1Kwq3TLqDQMbkbaRpSnoC28oWvjLeshoQz1StZ9YHM1EpcJ')
     assert.throws(function () {
       hdnode.privateExtendedKey()
-    }, /^Error: Private key is not available$/)
+    }, /^Error: This is a public key only wallet$/)
   })
   it('should work with private', function () {
     var hdnode = HDKey.fromExtendedKey('xprv9s21ZrQH143K4KqQx9Zrf1eN8EaPQVFxM2Ast8mdHn7GKiDWzNEyNdduJhWXToy8MpkGcKjxeFWd8oBSvsz4PCYamxR7TX49pSpp3bmHVAY')

--- a/thirdparty.js
+++ b/thirdparty.js
@@ -203,9 +203,10 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     /* eslint-disable new-cap */
     var decipher = new aesjs.ModeOfOperation.ecb(aesKey)
     /* eslint-enable new-cap */
+    /* decrypt returns an Uint8Array, perhaps there is a better way to concatenate */
     privKey = Buffer.concat([
-      decipher.decrypt(encryptedSeed.slice(0, 16)),
-      decipher.decrypt(encryptedSeed.slice(16, 32))
+      Buffer.from(decipher.decrypt(encryptedSeed.slice(0, 16))),
+      Buffer.from(decipher.decrypt(encryptedSeed.slice(16, 32)))
     ])
 
     if (checksum.length > 0) {


### PR DESCRIPTION
Fixes #24.

Still missing:
- ~~aes-js update (the API change broke it)~~ (*note: drops support for browsers <IE10*)
- ~~hdkey (asked them to make a release since master contains changes: https://github.com/cryptocoinjs/hdkey/issues/13)~~
- ~~should also update to [ethereumjs-util 5.1.4 once released](https://github.com/ethereumjs/ethereumjs-util/pull/116)~~