### PR TITLE
Update package.json to include published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Utilities for handling Ethereum keys",
   "main": "index.js",
   "files": [
-    "/*.js",
+    "*.js",
     "test/"
   ],
   "scripts": {


### PR DESCRIPTION
List the files that will be published to npm in the package.json so tools like [pkg](https://github.com/zeit/pkg) can correctly resolve files that are listed there.

Running `pkg` with any module that requires `ethereumjs-wallet` will result in the following error:

```
> Error! Error: EACCES: permission denied, scandir '/lost+found'
```

Correcting `/*.js` to `*.js` fixes this. :raised_hands: 