### PR TITLE
Org links and git hooks

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Great that you want to contribute to the `EthereumJS` [ecosystem](https://ethereumjs.readthedocs.io/en/latest/introduction.html). `EthereumJS` is managed by the Ethereum Foundation and largely driven by the wider community. Everyone is welcome to join the effort and help to improve on the libraries (see our [Code of Conduct](https://ethereumjs.readthedocs.io/en/latest/code_of_conduct.html) 🌷).
+
+We have written up some [Contribution Guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html#how-to-start) to help you getting started.
+
+These include information on how we work with **Git** and how our **general workflow** and **technical setup** looks like (stuff like language, tooling, code quality and style).
+
+Happy Coding! 👾 😀 💻

--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ The following settings are favoured by the Go Ethereum implementation and we def
 - `p`: `1`
 - `cipher`: `aes-128-ctr`
 
+# EthereumJS
+
+See our organizational [documentation](https://ethereumjs.readthedocs.io) for an introduction to `EthereumJS` as well as information on current standards and best practices.
+
+If you want to join for work or do improvements on the libraries have a look at our [contribution guidelines](https://ethereumjs.readthedocs.io/en/latest/contributing.html).
+
 ## License
 
 MIT License

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "test:build": "npm run build:dist && mocha ./test/*.js",
     "build:dist": "babel src/ -d ."
   },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run lint"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ethereumjs/ethereumjs-wallet.git"
@@ -46,6 +51,7 @@
     "babel-cli": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "coveralls": "^3.0.0",
+    "husky": "^2.1.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "standard": "^12.0.0"


### PR DESCRIPTION
Organization wide application of GitHooks https://github.com/ethereumjs/ethereumjs-account/pull/46 and organizational docs linking https://github.com/ethereumjs/ethereumjs-account/pull/49.