### PR TITLE
WIP: Remove scrypt.js dependency (help wanted)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "husky": "^2.1.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
-    "standard": "^12.0.0"
+    "standard": "^12.0.1"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "hdkey": "^1.1.1",
     "randombytes": "^2.0.6",
     "safe-buffer": "^5.1.2",
-    "scrypt.js": "^0.3.0",
     "utf8": "^3.0.0",
     "uuid": "^3.3.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,10 @@ Wallet.prototype.toV3 = function (password, opts) {
     kdfparams.n = opts.n || 262144
     kdfparams.r = opts.r || 8
     kdfparams.p = opts.p || 1
-    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
+    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.dklen, {"cost": kdfparams.n, "blockSize": kdfparams.r, "parallelization": kdfparams.p}, (err, derivedKey) => {
+      if (err) throw err;
+      console.log(derivedKey.toString('hex'));  // '3745e48...aa39b34'
+    })
   } else {
     throw new Error('Unsupported kdf')
   }
@@ -225,7 +228,10 @@ Wallet.fromV1 = function (input, password) {
   }
 
   var kdfparams = json.Crypto.KeyHeader.KdfParams
-  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.N, kdfparams.R, kdfparams.P, kdfparams.DkLen)
+  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.dklen, {"cost": kdfparams.n, "blockSize": kdfparams.r, "parallelization": kdfparams.p}, (err, derivedKey) => {
+    if (err) throw err;
+    console.log(derivedKey.toString('hex'));  // '3745e48...aa39b34'
+  })
 
   var ciphertext = Buffer.from(json.Crypto.CipherText, 'hex')
 
@@ -255,7 +261,10 @@ Wallet.fromV3 = function (input, password, nonStrict) {
     kdfparams = json.crypto.kdfparams
 
     // FIXME: support progress reporting callback
-    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
+    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {"cost": kdfparams.n, "blockSize": kdfparams.r, "parallelization": kdfparams.p}, (err, derivedKey) => {
+      if (err) throw err;
+      console.log(derivedKey.toString('hex'));  // '3745e48...aa39b34'
+    })
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams
 

--- a/src/index.js
+++ b/src/index.js
@@ -129,9 +129,9 @@ Wallet.prototype.toV3 = function (password, opts) {
     kdfparams.n = opts.n || 262144
     kdfparams.r = opts.r || 8
     kdfparams.p = opts.p || 1
-    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.dklen, {"cost": kdfparams.n, "blockSize": kdfparams.r, "parallelization": kdfparams.p}, (err, derivedKey) => {
-      if (err) throw err;
-      console.log(derivedKey.toString('hex'));  // '3745e48...aa39b34'
+    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p }, (err, derivedKey) => {
+      if (err) throw err
+      console.log(derivedKey.toString('hex')) // '3745e48...aa39b34'
     })
   } else {
     throw new Error('Unsupported kdf')
@@ -228,9 +228,9 @@ Wallet.fromV1 = function (input, password) {
   }
 
   var kdfparams = json.Crypto.KeyHeader.KdfParams
-  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.dklen, {"cost": kdfparams.n, "blockSize": kdfparams.r, "parallelization": kdfparams.p}, (err, derivedKey) => {
-    if (err) throw err;
-    console.log(derivedKey.toString('hex'));  // '3745e48...aa39b34'
+  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p }, (err, derivedKey) => {
+    if (err) throw err
+    console.log(derivedKey.toString('hex')) // '3745e48...aa39b34'
   })
 
   var ciphertext = Buffer.from(json.Crypto.CipherText, 'hex')
@@ -261,9 +261,9 @@ Wallet.fromV3 = function (input, password, nonStrict) {
     kdfparams = json.crypto.kdfparams
 
     // FIXME: support progress reporting callback
-    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {"cost": kdfparams.n, "blockSize": kdfparams.r, "parallelization": kdfparams.p}, (err, derivedKey) => {
-      if (err) throw err;
-      console.log(derivedKey.toString('hex'));  // '3745e48...aa39b34'
+    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p }, (err, derivedKey) => {
+      if (err) throw err
+      console.log(derivedKey.toString('hex')) // '3745e48...aa39b34'
     })
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ var Buffer = require('safe-buffer').Buffer
 var ethUtil = require('ethereumjs-util')
 var crypto = require('crypto')
 var randomBytes = require('randombytes')
-var scryptsy = require('scrypt.js')
 var uuidv4 = require('uuid/v4')
 var bs58check = require('bs58check')
 
@@ -130,7 +129,7 @@ Wallet.prototype.toV3 = function (password, opts) {
     kdfparams.n = opts.n || 262144
     kdfparams.r = opts.r || 8
     kdfparams.p = opts.p || 1
-    derivedKey = scryptsy(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
+    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
   } else {
     throw new Error('Unsupported kdf')
   }
@@ -226,7 +225,7 @@ Wallet.fromV1 = function (input, password) {
   }
 
   var kdfparams = json.Crypto.KeyHeader.KdfParams
-  var derivedKey = scryptsy(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.N, kdfparams.R, kdfparams.P, kdfparams.DkLen)
+  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.N, kdfparams.R, kdfparams.P, kdfparams.DkLen)
 
   var ciphertext = Buffer.from(json.Crypto.CipherText, 'hex')
 
@@ -256,7 +255,7 @@ Wallet.fromV3 = function (input, password, nonStrict) {
     kdfparams = json.crypto.kdfparams
 
     // FIXME: support progress reporting callback
-    derivedKey = scryptsy(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
+    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams
 

--- a/src/index.js
+++ b/src/index.js
@@ -129,10 +129,7 @@ Wallet.prototype.toV3 = function (password, opts) {
     kdfparams.n = opts.n || 262144
     kdfparams.r = opts.r || 8
     kdfparams.p = opts.p || 1
-    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p }, (err, derivedKey) => {
-      if (err) throw err
-      console.log(derivedKey.toString('hex')) // '3745e48...aa39b34'
-    })
+    derivedKey = crypto.scryptSync(Buffer.from(password), salt, kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p })
   } else {
     throw new Error('Unsupported kdf')
   }
@@ -228,10 +225,7 @@ Wallet.fromV1 = function (input, password) {
   }
 
   var kdfparams = json.Crypto.KeyHeader.KdfParams
-  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p }, (err, derivedKey) => {
-    if (err) throw err
-    console.log(derivedKey.toString('hex')) // '3745e48...aa39b34'
-  })
+  var derivedKey = crypto.scryptSync(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p })
 
   var ciphertext = Buffer.from(json.Crypto.CipherText, 'hex')
 
@@ -261,10 +255,7 @@ Wallet.fromV3 = function (input, password, nonStrict) {
     kdfparams = json.crypto.kdfparams
 
     // FIXME: support progress reporting callback
-    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p }, (err, derivedKey) => {
-      if (err) throw err
-      console.log(derivedKey.toString('hex')) // '3745e48...aa39b34'
-    })
+    derivedKey = crypto.scryptSync(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, { 'cost': kdfparams.n, 'blockSize': kdfparams.r, 'parallelization': kdfparams.p })
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams
 

--- a/src/thirdparty.js
+++ b/src/thirdparty.js
@@ -1,7 +1,6 @@
 var Wallet = require('./index.js')
 var ethUtil = require('ethereumjs-util')
 var crypto = require('crypto')
-var scryptsy = require('scrypt.js')
 var utf8 = require('utf8')
 var aesjs = require('aes-js')
 var Buffer = require('safe-buffer').Buffer
@@ -186,7 +185,7 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     var checksum = entropy.slice(30, 46)
 
     var salt = kryptoKitBrokenScryptSeed(encryptedSeed)
-    var aesKey = scryptsy(Buffer.from(password, 'utf8'), salt, 16384, 8, 1, 32)
+    var aesKey = crypto.scrypt(Buffer.from(password, 'utf8'), salt, 16384, 8, 1, 32)
 
     /* FIXME: try to use `crypto` instead of `aesjs`
 

--- a/src/thirdparty.js
+++ b/src/thirdparty.js
@@ -185,7 +185,15 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     var checksum = entropy.slice(30, 46)
 
     var salt = kryptoKitBrokenScryptSeed(encryptedSeed)
-    var aesKey = crypto.scrypt(Buffer.from(password, 'utf8'), salt, 16384, 8, 1, 32)
+    var dklen = 32
+    var n = 16384
+    var r = 8
+    var p = 1
+
+    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, dklen, {"cost": n, "blockSize": r, "parallelization": p}, (err, aesKey) => {
+      if (err) throw err;
+      console.log(aesKey.toString('hex'));  // '3745e48...aa39b34'
+    })
 
     /* FIXME: try to use `crypto` instead of `aesjs`
 

--- a/src/thirdparty.js
+++ b/src/thirdparty.js
@@ -190,9 +190,9 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     var r = 8
     var p = 1
 
-    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, dklen, {"cost": n, "blockSize": r, "parallelization": p}, (err, aesKey) => {
-      if (err) throw err;
-      console.log(aesKey.toString('hex'));  // '3745e48...aa39b34'
+    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, dklen, { 'cost': n, 'blockSize': r, 'parallelization': p }, (err, aesKey) => {
+      if (err) throw err
+      console.log(aesKey.toString('hex')) // '3745e48...aa39b34'
     })
 
     /* FIXME: try to use `crypto` instead of `aesjs`

--- a/src/thirdparty.js
+++ b/src/thirdparty.js
@@ -190,10 +190,7 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     var r = 8
     var p = 1
 
-    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, dklen, { 'cost': n, 'blockSize': r, 'parallelization': p }, (err, aesKey) => {
-      if (err) throw err
-      console.log(aesKey.toString('hex')) // '3745e48...aa39b34'
-    })
+    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, dklen, { 'cost': n, 'blockSize': r, 'parallelization': p })
 
     /* FIXME: try to use `crypto` instead of `aesjs`
 


### PR DESCRIPTION
I'm trying to remove scrypt.js, which is no longer maintained as a dependency. The primary reason is that scrypt.js isn't compatible with node12. A secondary benefit is that we can remove a dependency.

## Deprecation
scrypt.js isn't compatible with node12, see:
- https://github.com/dappnode/DAppNodeSDK/issues/34
- https://github.com/syscoin/sysethereum-contracts/issues/1
- https://github.com/barrysteyn/node-scrypt/commit/8c7e3fce9efbab2bc0eab677721483870002f76e

## Testing errors
When testing these changes, I'm hitting out of memory errors:
```

> ethereumjs-wallet@0.6.3 test /Users/nathaniel/src/ethereumjs/ethereumjs-wallet
> mocha ./src/test/*.js



  .fromMasterSeed()
    ✓ should work

  .privateExtendedKey()
    ✓ should work

  .publicExtendedKey()
    ✓ should work

  .fromExtendedKey()
    ✓ should work with public
    ✓ should work with private

  .deriveChild()
    ✓ should work

  .derivePath()
    ✓ should work with m
    ✓ should work with m/44'/0'/0/1

  .getWallet()
    ✓ should work
    ✓ should work with public nodes

  .getPrivateKey()
    ✓ should work
    ✓ should fail

  .getPrivateKeyString()
    ✓ should work

  .getPublicKey()
    ✓ should work

  .getPublicKeyString()
    ✓ should work

  .getAddress()
    ✓ should work

  .getAddressString()
    ✓ should work

  .getChecksumAddressString()
    ✓ should work

  public key only wallet
    ✓ .fromPublicKey() should work
    ✓ .fromPublicKey() should not accept compressed keys in strict mode
    ✓ .fromPublicKey() should accept compressed keys in non-strict mode
    ✓ .getAddress() should work
    ✓ .getPrivateKey() should fail
    ✓ .toV3() should fail

  .fromExtendedPrivateKey()
    ✓ should work

  .fromExtendedPublicKey()
    ✓ should work

  .generate()
    ✓ should generate an account
    ✓ should generate an account compatible with ICAP Direct

  .generateVanityAddress()
    ✓ should generate an account with 000 prefix (object) (257ms)
    ✓ should generate an account with 000 prefix (string) (41ms)

  .getV3Filename()
    ✓ should work

  .toV3()
    ✓ should work with PBKDF2 (119ms)
    1) should work with Scrypt
    2) should work without providing options
    ✓ should fail for unsupported kdf

  .fromV3()
    ✓ should work with PBKDF2 (122ms)
    3) should work with Scrypt
    4) should work with 'unencrypted' wallets
    ✓ should fail with invalid password (121ms)
    ✓ should work with (broken) mixed-case input files (119ms)
    ✓ shouldn't work with (broken) mixed-case input files in strict mode
    ✓ should fail for wrong version
    ✓ should fail for wrong kdf
    ✓ should fail for wrong prf in pbkdf2

  .fromEthSale()
    ✓ should work with short password (8 characters)
    ✓ should work with long password (19 characters)
    ✓ should work with pyethrecover's wallet

  .fromEtherWallet()
    ✓ should work with unencrypted input
    ✓ should work with encrypted input

  .fromEtherCamp()
    ✓ should work with seed text

  .fromKryptoKit()
    ✓ should work with basic input (d-type)
    ✓ should work with encrypted input (q-type) (50ms)

  .fromQuorumWallet()
    ✓ should work

  raw new Wallet() init
    ✓ should fail when both priv and pub key provided


  50 passing (872ms)
  4 failing

  1) .toV3()
       should work with Scrypt:
     Error: error:060B50AC:digital envelope routines:EVP_PBE_scrypt:memory limit exceeded
      at handleError (internal/crypto/scrypt.js:62:14)
      at Object.scrypt (internal/crypto/scrypt.js:47:3)
      at Wallet.toV3 (src/index.js:132:25)
      at Wallet.toV3String (src/index.js:189:30)
      at Context.<anonymous> (src/test/index.js:158:38)
      at processImmediate (internal/timers.js:439:21)

  2) .toV3()
       should work without providing options:
     Error: error:060B50AC:digital envelope routines:EVP_PBE_scrypt:memory limit exceeded
      at handleError (internal/crypto/scrypt.js:62:14)
      at Object.scrypt (internal/crypto/scrypt.js:47:3)
      at Wallet.toV3 (src/index.js:132:25)
      at Context.<anonymous> (src/test/index.js:162:38)
      at processImmediate (internal/timers.js:439:21)

  3) .fromV3()
       should work with Scrypt:
     Error: error:060B50AC:digital envelope routines:EVP_PBE_scrypt:memory limit exceeded
      at handleError (internal/crypto/scrypt.js:62:14)
      at Object.scrypt (internal/crypto/scrypt.js:47:3)
      at Function.Wallet.fromV3 (src/index.js:264:25)
      at Context.<anonymous> (src/test/index.js:190:25)
      at processImmediate (internal/timers.js:439:21)

  4) .fromV3()
       should work with 'unencrypted' wallets:
     Error: error:060B50AC:digital envelope routines:EVP_PBE_scrypt:memory limit exceeded
      at handleError (internal/crypto/scrypt.js:62:14)
      at Object.scrypt (internal/crypto/scrypt.js:47:3)
      at Function.Wallet.fromV3 (src/index.js:264:25)
      at Context.<anonymous> (src/test/index.js:196:25)
      at processImmediate (internal/timers.js:439:21)



npm ERR! Test failed.  See above for more details.
```
For [crypto.scrypt](https://nodejs.org/api/crypto.html#crypto_crypto_scrypt_password_salt_keylen_options_callback) and scrypto.scryptSync, there is a `maxmem` optional argument that can be passed. I tried a couple different values but keep hitting "memory limit exceeded" errors. I'm not sure what the memory limit should be.


## callback?
One thing I noticed when reading the code was that was a mention in the comments about [using a callback](https://github.com/Leibniz137/ethereumjs-wallet/blob/3c9bfa21cbf75f36211f3bc2f4d353ec34fd1865/src/index.js#L128).

Note that the asynchonous version of the `crypto.scrypt` function requires a callback be passed.
I don't know what the definition of the callback would be if we passed it. Suggestions welcome!

## crypto.scrypt vs crypto.scryptSync?
Should these function calls be synchronous or async? I don't know what the callback defs should be, so I'm using the synchronous version at this point. But if the callback question is answered, perhaps we can switch to the asynch version?

## cryptographic gotchas/concerns?
I'm not a cryptographer and I don't have a good understanding of these libraries. Obviously before merging someone with some background in cryptography should OK these changes.