### PR TITLE
remove scrypt.js dependency for node 12, use native node 12 instead. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - "6"
   - "8"
   - "10"
+  - "12"
 env:
   - CXX=g++-4.8
 addons:

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "hdkey": "^1.1.1",
     "randombytes": "^2.0.6",
     "safe-buffer": "^5.1.2",
-    "scrypt.js": "^0.3.0",
     "utf8": "^3.0.0",
     "uuid": "^3.3.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ var Buffer = require('safe-buffer').Buffer
 var ethUtil = require('ethereumjs-util')
 var crypto = require('crypto')
 var randomBytes = require('randombytes')
-var crypto = require('crypto')
 var uuidv4 = require('uuid/v4')
 var bs58check = require('bs58check')
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ var Buffer = require('safe-buffer').Buffer
 var ethUtil = require('ethereumjs-util')
 var crypto = require('crypto')
 var randomBytes = require('randombytes')
-var scryptsy = require('scrypt.js')
+var crypto = require('crypto')
 var uuidv4 = require('uuid/v4')
 var bs58check = require('bs58check')
 
@@ -130,7 +130,7 @@ Wallet.prototype.toV3 = function (password, opts) {
     kdfparams.n = opts.n || 262144
     kdfparams.r = opts.r || 8
     kdfparams.p = opts.p || 1
-    derivedKey = scryptsy(Buffer.from(password), salt, kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
+    derivedKey = crypto.scryptSync(Buffer.from(password), salt, kdfparams.dklen, {N: kdfparams.n, r: kdfparams.r, p: kdfparams.p});
   } else {
     throw new Error('Unsupported kdf')
   }
@@ -226,7 +226,8 @@ Wallet.fromV1 = function (input, password) {
   }
 
   var kdfparams = json.Crypto.KeyHeader.KdfParams
-  var derivedKey = scryptsy(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.N, kdfparams.R, kdfparams.P, kdfparams.DkLen)
+  var derivedKey = crypto.scryptSync(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.Dklen, {N: kdfparams.N, r: kdfparams.R, p: kdfparams.P});
+
 
   var ciphertext = Buffer.from(json.Crypto.CipherText, 'hex')
 
@@ -256,7 +257,7 @@ Wallet.fromV3 = function (input, password, nonStrict) {
     kdfparams = json.crypto.kdfparams
 
     // FIXME: support progress reporting callback
-    derivedKey = scryptsy(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.n, kdfparams.r, kdfparams.p, kdfparams.dklen)
+    derivedKey = crypto.scryptSync(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {N: kdfparams.n, r: kdfparams.r, p: kdfparams.p});
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams
 

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ Wallet.prototype.toV3 = function (password, opts) {
     kdfparams.n = opts.n || 262144
     kdfparams.r = opts.r || 8
     kdfparams.p = opts.p || 1
-    derivedKey = crypto.scryptSync(Buffer.from(password), salt, kdfparams.dklen, {N: kdfparams.n, r: kdfparams.r, p: kdfparams.p});
+    derivedKey = crypto.scrypt(Buffer.from(password), salt, kdfparams.dklen, {N: kdfparams.n, r: kdfparams.r, p: kdfparams.p});
   } else {
     throw new Error('Unsupported kdf')
   }
@@ -225,7 +225,7 @@ Wallet.fromV1 = function (input, password) {
   }
 
   var kdfparams = json.Crypto.KeyHeader.KdfParams
-  var derivedKey = crypto.scryptSync(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.Dklen, {N: kdfparams.N, r: kdfparams.R, p: kdfparams.P});
+  var derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(json.Crypto.Salt, 'hex'), kdfparams.Dklen, {N: kdfparams.N, r: kdfparams.R, p: kdfparams.P});
 
 
   var ciphertext = Buffer.from(json.Crypto.CipherText, 'hex')
@@ -256,7 +256,7 @@ Wallet.fromV3 = function (input, password, nonStrict) {
     kdfparams = json.crypto.kdfparams
 
     // FIXME: support progress reporting callback
-    derivedKey = crypto.scryptSync(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {N: kdfparams.n, r: kdfparams.r, p: kdfparams.p});
+    derivedKey = crypto.scrypt(Buffer.from(password), Buffer.from(kdfparams.salt, 'hex'), kdfparams.dklen, {N: kdfparams.n, r: kdfparams.r, p: kdfparams.p});
   } else if (json.crypto.kdf === 'pbkdf2') {
     kdfparams = json.crypto.kdfparams
 

--- a/src/thirdparty.js
+++ b/src/thirdparty.js
@@ -185,7 +185,7 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     var checksum = entropy.slice(30, 46)
 
     var salt = kryptoKitBrokenScryptSeed(encryptedSeed)
-    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, 32, {N: 16384, r: 8, p: 1});
+    var aesKey = crypto.scrypt(Buffer.from(password, 'utf8'), salt, 32, {N: 16384, r: 8, p: 1});
 
     /* FIXME: try to use `crypto` instead of `aesjs`
 

--- a/src/thirdparty.js
+++ b/src/thirdparty.js
@@ -1,7 +1,6 @@
 var Wallet = require('./index.js')
 var ethUtil = require('ethereumjs-util')
 var crypto = require('crypto')
-var scryptsy = require('scrypt.js')
 var utf8 = require('utf8')
 var aesjs = require('aes-js')
 var Buffer = require('safe-buffer').Buffer
@@ -186,7 +185,7 @@ Thirdparty.fromKryptoKit = function (entropy, password) {
     var checksum = entropy.slice(30, 46)
 
     var salt = kryptoKitBrokenScryptSeed(encryptedSeed)
-    var aesKey = scryptsy(Buffer.from(password, 'utf8'), salt, 16384, 8, 1, 32)
+    var aesKey = crypto.scryptSync(Buffer.from(password, 'utf8'), salt, 32, {N: 16384, r: 8, p: 1});
 
     /* FIXME: try to use `crypto` instead of `aesjs`
 


### PR DESCRIPTION
scrypt.js uses the unmaintained module scrypt.
This does not work with Node 12.
I'm proposing this change for future versions.
I had to edit this for a Node 12 project and thought a PR might be in order.

https://github.com/barrysteyn/node-scrypt/issues/193