### PR TITLE
Test downgraded BN.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@web3-js/scrypt-shim": "^0.1.0",
     "aes-js": "^3.1.1",
+    "bn.js": "^4.11.8",
     "bs58check": "^2.1.2",
     "ethereumjs-util": "^7.0.0",
     "hdkey": "^1.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import * as ethUtil from 'ethereumjs-util'
 export { default as hdkey } from './hdkey'
 export { default as thirdparty } from './thirdparty'
 
+const BN = require('bn.js')
 const bs58check = require('bs58check')
 const randomBytes = require('randombytes')
 const scryptsy = require('@web3-js/scrypt-shim')
@@ -253,10 +254,10 @@ export default class Wallet {
    */
   public static generate(icapDirect: boolean = false): Wallet {
     if (icapDirect) {
-      const max = new ethUtil.BN('088f924eeceeda7fe92e1f5b0fffffffffffffff', 16)
+      const max = new BN('088f924eeceeda7fe92e1f5b0fffffffffffffff', 16)
       while (true) {
         const privateKey = randomBytes(32) as Buffer
-        if (new ethUtil.BN(ethUtil.privateToAddress(privateKey)).lte(max)) {
+        if (new BN(ethUtil.privateToAddress(privateKey)).lte(max)) {
           return new Wallet(privateKey)
         }
       }

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,8 +1,8 @@
 /* tslint:disable no-invalid-this */
 import * as assert from 'assert'
-import { BN } from 'ethereumjs-util'
 import { Wallet as ethersWallet } from 'ethers'
 
+const BN = require('bn.js')
 const zip = require('lodash.zip')
 
 import Wallet from '../src'


### PR DESCRIPTION
Use standalone BN.js v4.11.8 instead of Util v5 re-exported BN.js v5 to solve missing r._strip issue on browser tests.

This is a test run, DO NOT MERGE FOR NOW.