### PR TITLE
Updated ethereumjs-util dependency to v7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "aes-js": "^3.1.1",
     "bs58check": "^2.1.2",
-    "ethereumjs-util": "^7.0.1",
+    "ethereumjs-util": "^7.0.2",
     "hdkey": "^1.1.1",
     "randombytes": "^2.0.6",
     "scrypt-js": "^3.0.1",


### PR DESCRIPTION
(Hopefully) final iteration on this to bump the Util dependency to [v7.0.2](https://github.com/ethereumjs/ethereumjs-util/releases/tag/v7.0.2) using the BN.js `v5` re-export.