### PR TITLE
Removing hdkey native dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "aes-js": "^3.1.1",
     "bs58check": "^2.1.2",
+    "ethereum-cryptography": "^0.1.3",
     "ethereumjs-util": "^7.0.2",
-    "hdkey": "^2.0.1",
     "randombytes": "^2.0.6",
     "scrypt-js": "^3.0.1",
     "utf8": "^3.0.0",

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -1,6 +1,6 @@
 import Wallet from './index'
 
-const { HDKey } = require('ethereum-cryptography/hdkey')
+import { HDKey } from 'ethereum-cryptography/hdkey'
 
 export default class EthereumHDKey {
   /**

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -1,6 +1,6 @@
 import Wallet from './index'
 
-const { HDKey } = require('ethereum-cryptography/hdkey');
+const { HDKey } = require('ethereum-cryptography/hdkey')
 
 export default class EthereumHDKey {
   /**

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -1,6 +1,6 @@
 import Wallet from './index'
 
-const HDKey = require('hdkey')
+const { HDKey } = require('ethereum-cryptography/hdkey');
 
 export default class EthereumHDKey {
   /**


### PR DESCRIPTION
This PR removes hdkey dependency and instead uses ethereum-cryptography package that doesn't require native dependency compiling.