### PR TITLE
Fix issue with buffer concatenation while using scrypt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -599,7 +599,7 @@ export default class Wallet {
     }
 
     const ciphertext = runCipherBuffer(cipher, this.privKey)
-    const mac = keccak256(Buffer.concat([derivedKey.slice(16, 32), Buffer.from(ciphertext)]))
+    const mac = keccak256(Buffer.concat([Buffer.from(derivedKey.slice(16, 32)), Buffer.from(ciphertext)]))
 
     return {
       version: 3,

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,7 @@ export default class Wallet {
     }
 
     const ciphertext = Buffer.from(json.crypto.ciphertext, 'hex')
-    const mac = keccak256(Buffer.concat([derivedKey.slice(16, 32), ciphertext]))
+    const mac = keccak256(Buffer.concat([Buffer.from(derivedKey.slice(16, 32)), ciphertext]))
     if (mac.toString('hex') !== json.crypto.mac) {
       throw new Error('Key derivation failed - possibly wrong passphrase')
     }


### PR DESCRIPTION
While using scrypt, derivedKey is of type Uint8Array. While concatenating, Buffer checks for isBuffer and throws.!
This PR fixes that