### PR TITLE
Add named export for Wallet class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -599,7 +599,9 @@ class Wallet {
     }
 
     const ciphertext = runCipherBuffer(cipher, this.privKey)
-    const mac = keccak256(Buffer.concat([Buffer.from(derivedKey.slice(16, 32)), Buffer.from(ciphertext)]))
+    const mac = keccak256(
+      Buffer.concat([Buffer.from(derivedKey.slice(16, 32)), Buffer.from(ciphertext)]),
+    )
 
     return {
       version: 3,

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,7 +237,7 @@ interface EthSaleKeystore {
 
 // wallet implementation
 
-export default class Wallet {
+class Wallet {
   constructor(
     private readonly privateKey?: Buffer | undefined,
     private publicKey: Buffer | undefined = undefined,
@@ -645,6 +645,9 @@ export default class Wallet {
     return JSON.stringify(await this.toV3(password, opts))
   }
 }
+
+export default Wallet
+export { Wallet }
 
 // helpers
 


### PR DESCRIPTION
This PR adds a named export for the Wallet class to match the README docs.

It does not remove the default export as it currently exists to not introduce any breaking changes.

Closes #144 