### PR TITLE
Update README.md ES5 import

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can import the `Wallet` class like this
 Node.js / ES5:
 
 ```js
-const { Wallet } = require('ethereumjs-wallet').default
+const wallet = require('ethereumjs-wallet').default;
 ```
 
 ESM / TypeScript:


### PR DESCRIPTION
`const { Wallet } = require('ethereumjs-wallet').default`

 does not work, should be: 
 
 `const wallet = require('ethereumjs-wallet').default;`
 