### PR TITLE
ci: separate browser test to own actions run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,30 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x, 16.x]
+        node-version: [12, 13, 14, 16]
     steps:
       - uses: actions/checkout@v2
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
-
-      - run: npm install
-      - run: npm run coverage 
-      - run: npm run test:browser
-
+      - run: npm i
+      - run: npm run lint
+      - run: npm run coverage
       - name: Upload coverage to Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          
+        if: ${{ matrix.node-version == 12 }}
+  test-browser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+      - run: npm i
+      - run: npm run test:browser

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dist.browser"
   ],
   "scripts": {
+    "postinstall": "npm run build",
     "build": "tsc -p ./tsconfig.prod.json && tsc -p tsconfig.browser.json",
     "prepublishOnly": "npm run lint && npm run build && npm run test",
     "docs:build": "typedoc --out docs --mode file --readme none --theme markdown --mdEngine github --excludeNotExported src",
@@ -18,7 +19,7 @@
     "tsc": "tsc -p ./tsconfig.prod.json --noEmit",
     "lint": "ethereumjs-config-lint",
     "lint:fix": "ethereumjs-config-lint-fix",
-    "test": "npm run lint && npm run build && npm run test:unit && npm run test:browser",
+    "test": "npm run test:unit && npm run test:browser",
     "test:unit": "mocha --require ts-node/register ./test/**/*.ts",
     "test:browser": "karma start karma.conf.js"
   },


### PR DESCRIPTION
While working on #157 I merged the browser test into the unit test ci run, at the time I didn't realize how long the browser tests took to execute so this separates it back into its own run for efficiency's sake.