### PR TITLE
Add fromMnemonic function

### DIFF
--- a/docs/classes/ethereumhdkey.md
+++ b/docs/classes/ethereumhdkey.md
@@ -25,6 +25,7 @@
 - [publicExtendedKey](ethereumhdkey.md#publicextendedkey)
 - [fromExtendedKey](ethereumhdkey.md#fromextendedkey)
 - [fromMasterSeed](ethereumhdkey.md#frommasterseed)
+- [fromMnemonic](ethereumhdkey.md#frommnemonic)
 
 ---
 
@@ -36,7 +37,7 @@
 
 ⊕ **new EthereumHDKey**(\_hdkey: _`any`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:21](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L21)_
+_Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L27)_
 
 **Parameters:**
 
@@ -56,7 +57,7 @@ _Defined in [hdkey.ts:21](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 **● \_hdkey**: _`any`_
 
-_Defined in [hdkey.ts:23](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L23)_
+_Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L27)_
 
 ---
 
@@ -68,7 +69,7 @@ _Defined in [hdkey.ts:23](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **deriveChild**(index: _`number`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:52](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L52)_
+_Defined in [hdkey.ts:56](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L56)_
 
 **Parameters:**
 
@@ -86,7 +87,7 @@ _Defined in [hdkey.ts:52](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **derivePath**(path: _`string`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:45](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L45)_
+_Defined in [hdkey.ts:49](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L49)_
 
 **Parameters:**
 
@@ -104,7 +105,7 @@ _Defined in [hdkey.ts:45](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **getWallet**(): [Wallet](wallet.md)
 
-_Defined in [hdkey.ts:59](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L59)_
+_Defined in [hdkey.ts:63](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L63)_
 
 **Returns:** [Wallet](wallet.md)
 
@@ -116,7 +117,7 @@ _Defined in [hdkey.ts:59](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **privateExtendedKey**(): `Buffer`
 
-_Defined in [hdkey.ts:28](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L28)_
+_Defined in [hdkey.ts:32](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L32)_
 
 **Returns:** `Buffer`
 
@@ -128,7 +129,7 @@ _Defined in [hdkey.ts:28](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **publicExtendedKey**(): `Buffer`
 
-_Defined in [hdkey.ts:38](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L38)_
+_Defined in [hdkey.ts:42](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L42)_
 
 **Returns:** `Buffer`
 
@@ -140,7 +141,7 @@ _Defined in [hdkey.ts:38](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **fromExtendedKey**(base58Key: _`string`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:19](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L19)_
+_Defined in [hdkey.ts:23](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L23)_
 
 **Parameters:**
 
@@ -158,13 +159,32 @@ _Defined in [hdkey.ts:19](https://github.com/ethereumjs/ethereumjs-wallet/blob/1
 
 ▸ **fromMasterSeed**(seedBuffer: _`Buffer`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:12](https://github.com/ethereumjs/ethereumjs-wallet/blob/13fb20d/src/hdkey.ts#L12)_
+_Defined in [hdkey.ts:9](https://github.com/ethereumjs/ethereumjs-wallet/blob/5f6d93/src/hdkey.ts#L9)_
 
 **Parameters:**
 
 | Name       | Type     |
 | ---------- | -------- |
 | seedBuffer | `Buffer` |
+
+**Returns:** [EthereumHDKey](ethereumhdkey.md)
+
+---
+
+<a id="frommnemonic"></a>
+
+### `<Static>` fromMnemonic
+
+▸ **fromMnemonic**(mnemonic: _`string`_, passphrase: _`string`_): [EthereumHDKey](ethereumhdkey.md)
+
+_Defined in [hdkey.ts:16](https://github.com/ethereumjs/ethereumjs-wallet/blob/5f6d93/src/hdkey.ts#L16)_
+
+**Parameters:**
+
+| Name       | Type     |
+| ---------- | -------- |
+| mnemonic | `string` |
+| `Optional` passphrase | `string` |
 
 **Returns:** [EthereumHDKey](ethereumhdkey.md)
 

--- a/docs/classes/ethereumhdkey.md
+++ b/docs/classes/ethereumhdkey.md
@@ -37,7 +37,7 @@
 
 ⊕ **new EthereumHDKey**(\_hdkey: _`any`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L27)_
+_Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L27)_
 
 **Parameters:**
 
@@ -57,7 +57,7 @@ _Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 **● \_hdkey**: _`any`_
 
-_Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L27)_
+_Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L27)_
 
 ---
 
@@ -69,7 +69,7 @@ _Defined in [hdkey.ts:27](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **deriveChild**(index: _`number`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:56](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L56)_
+_Defined in [hdkey.ts:56](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L56)_
 
 **Parameters:**
 
@@ -87,7 +87,7 @@ _Defined in [hdkey.ts:56](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **derivePath**(path: _`string`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:49](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L49)_
+_Defined in [hdkey.ts:49](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L49)_
 
 **Parameters:**
 
@@ -105,7 +105,7 @@ _Defined in [hdkey.ts:49](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **getWallet**(): [Wallet](wallet.md)
 
-_Defined in [hdkey.ts:63](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L63)_
+_Defined in [hdkey.ts:63](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L63)_
 
 **Returns:** [Wallet](wallet.md)
 
@@ -117,7 +117,7 @@ _Defined in [hdkey.ts:63](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **privateExtendedKey**(): `Buffer`
 
-_Defined in [hdkey.ts:32](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L32)_
+_Defined in [hdkey.ts:32](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L32)_
 
 **Returns:** `Buffer`
 
@@ -129,7 +129,7 @@ _Defined in [hdkey.ts:32](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **publicExtendedKey**(): `Buffer`
 
-_Defined in [hdkey.ts:42](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L42)_
+_Defined in [hdkey.ts:42](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L42)_
 
 **Returns:** `Buffer`
 
@@ -141,7 +141,7 @@ _Defined in [hdkey.ts:42](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **fromExtendedKey**(base58Key: _`string`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:23](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac0/src/hdkey.ts#L23)_
+_Defined in [hdkey.ts:23](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L23)_
 
 **Parameters:**
 
@@ -159,7 +159,7 @@ _Defined in [hdkey.ts:23](https://github.com/ethereumjs/ethereumjs-wallet/blob/7
 
 ▸ **fromMasterSeed**(seedBuffer: _`Buffer`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:9](https://github.com/ethereumjs/ethereumjs-wallet/blob/5f6d93/src/hdkey.ts#L9)_
+_Defined in [hdkey.ts:9](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L9)_
 
 **Parameters:**
 
@@ -177,7 +177,7 @@ _Defined in [hdkey.ts:9](https://github.com/ethereumjs/ethereumjs-wallet/blob/5f
 
 ▸ **fromMnemonic**(mnemonic: _`string`_, passphrase: _`string`_): [EthereumHDKey](ethereumhdkey.md)
 
-_Defined in [hdkey.ts:16](https://github.com/ethereumjs/ethereumjs-wallet/blob/5f6d93/src/hdkey.ts#L16)_
+_Defined in [hdkey.ts:16](https://github.com/ethereumjs/ethereumjs-wallet/blob/7b6ac09/src/hdkey.ts#L16)_
 
 **Parameters:**
 

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -13,7 +13,7 @@ export default class EthereumHDKey {
   /**
    * Creates an instance based on BIP39 mnemonic phrases
    */
-  public static fromMnemonic(mnemonic: string, passphrase?: string) {
+  public static fromMnemonic(mnemonic: string, passphrase?: string): EthereumHDKey {
     return EthereumHDKey.fromMasterSeed(Buffer.from(mnemonicToSeedSync(mnemonic, passphrase)))
   }
 

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -14,7 +14,7 @@ export default class EthereumHDKey {
    * Creates an instance based on BIP39 mnemonic phrases
    */
   public static fromMnemonic(mnemonic: string, passphrase?: string) {
-    return new EthereumHDKey(HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase)))
+    return EthereumHDKey.fromMasterSeed(Buffer.from(mnemonicToSeedSync(mnemonic, passphrase)))
   }
 
   /**

--- a/src/hdkey.ts
+++ b/src/hdkey.ts
@@ -1,15 +1,20 @@
 import { HDKey } from 'ethereum-cryptography/hdkey'
+import { mnemonicToSeedSync } from 'ethereum-cryptography/bip39'
 import Wallet from './index'
 
 export default class EthereumHDKey {
   /**
    * Creates an instance based on a seed.
-   *
-   * For the seed we suggest to use [bip39](https://npmjs.org/package/bip39) to
-   * create one from a BIP39 mnemonic.
    */
   public static fromMasterSeed(seedBuffer: Buffer): EthereumHDKey {
     return new EthereumHDKey(HDKey.fromMasterSeed(seedBuffer))
+  }
+
+  /**
+   * Creates an instance based on BIP39 mnemonic phrases
+   */
+  public static fromMnemonic(mnemonic: string, passphrase?: string) {
+    return new EthereumHDKey(HDKey.fromMasterSeed(mnemonicToSeedSync(mnemonic, passphrase)))
   }
 
   /**

--- a/test/hdkey.spec.ts
+++ b/test/hdkey.spec.ts
@@ -7,12 +7,32 @@ const fixtureseed = Buffer.from(
   'hex'
 )
 const fixturehd = EthereumHDKey.fromMasterSeed(fixtureseed)
+const fixtureMnemonic = 'awake book subject inch gentle blur grant damage process float month clown'
+const fixtureAddress = '0x4dcccf58c6573eb896250b0c9647a40c1673af44'
+const fixturePrivateKey = '0xf62a8ea4ab7025d151ccd84981c66278d0d3cd58ff837467cdc51229915a22d1'
 
 describe('.fromMasterSeed()', function () {
   it('should work', function () {
     assert.doesNotThrow(function () {
       EthereumHDKey.fromMasterSeed(fixtureseed)
     })
+  })
+})
+
+describe('.fromMnemonic()', function () {
+  it('should work', function () {
+    assert.doesNotThrow(function () {
+      EthereumHDKey.fromMnemonic(fixtureMnemonic)
+    })
+  })
+
+  it('should match', function () {
+    const path = "m/44'/60'/0'/0/0"
+    const hdWallet = EthereumHDKey.fromMnemonic(fixtureMnemonic)
+    const wallet = hdWallet.derivePath(path).getWallet()
+
+    assert.strictEqual(wallet.getPrivateKeyString(), fixturePrivateKey)
+    assert.strictEqual(wallet.getAddressString(), fixtureAddress)
   })
 })
 


### PR DESCRIPTION
closes #178

Requiring BIP39 dependency is useless since the functionality of converting BIP39 mnemonic phrases are already in the imported package.

And, lower count of dependency => better security for the codebase